### PR TITLE
Update Example to Use New `classification` Feature Extractor Method

### DIFF
--- a/javascript/FeatureExtractor_Image_Classification/sketch.js
+++ b/javascript/FeatureExtractor_Image_Classification/sketch.js
@@ -39,7 +39,7 @@ function modelLoaded() {
 // Extract the already learned features from MobileNet
 const featureExtractor = ml5.featureExtractor('MobileNet', modelLoaded);
 // Create a new classifier using those features
-const classifier = featureExtractor.asClassifier(video);
+const classifier = featureExtractor.classification(video);
 
 // Predict the current frame.
 function predict() {


### PR DESCRIPTION
Per result of:  https://github.com/ml5js/ml5-library/issues/128

Change method used from `asClassifier` to `classification`.